### PR TITLE
Quality of Life (QoL) and Reverse Heat Extreme Measures Scripts

### DIFF
--- a/Polycosmos/PolycosmosExtremeMeasures.lua
+++ b/Polycosmos/PolycosmosExtremeMeasures.lua
@@ -1,0 +1,11 @@
+-- Remove this file if empty .lua files aren't functional, or even welcome.
+
+-- Goal: Have Extreme Measures in the Pact of Punishment create the following upgraded bosses per level.
+-- 1.) Extreme Measures 4 = Sisters, Lernie, Heroes, Hades
+-- 2.) Extreme Measures 3 = Lernie, Heroes, Hades
+-- 3.) Extreme Measures 2 = Heroes, Hades
+-- 4.) Extreme Measures 4 = Hades
+
+-- For Archipelago in the future, we need to do 2 more things to this file:
+-- 1.) When Reverse Heat becomes an option instead of the primary playstyle, this needs to be enabled when Reverse Heat is enabled.
+-- 2.) When Reverse Extreme Measures is enabled, look into modifying AP logic to expect one (1) ExtremeMeasurePactLevel item per biome.

--- a/Polycosmos/PolycosmosQoL.lua
+++ b/Polycosmos/PolycosmosQoL.lua
@@ -1,0 +1,138 @@
+-- QoL 1: Allow the Broker to have all available options when the lounge is unlocked, regardless of furthest progression.
+
+-- StoreData.lua
+ModUtil.LoadOnce(function()
+
+-- Remove "GameStateRequirements" line for all applicable.
+BrokerData = 
+{
+	-- Standard Trades
+
+	{ 
+		BuyName = "LockKeys", BuyAmount = 1,
+		CostName = "Gems", CostAmount = 10, 
+		Priority = true, 
+		PurchaseSound = "/SFX/KeyPickup",
+	},
+
+	{ 
+		BuyName = "GiftPoints", BuyAmount = 1,
+		CostName = "LockKeys", CostAmount = 5, 
+		Priority = true, 
+		PurchaseSound = "/SFX/GiftAmbrosiaBottlePickup",
+	},
+
+	{ 
+		BuyName = "SuperGems", BuyAmount = 1,
+		CostName = "GiftPoints", CostAmount = 10, 
+		Priority = true,
+		PurchaseSound = "/SFX/SuperGemPickup",
+		-- GameStateRequirements = { RequiredKills = { HydraHeadImmortal = 1 }, },
+	},
+
+	{ 
+		BuyName = "SuperGiftPoints", BuyAmount = 1,
+		CostName = "SuperGems", CostAmount = 2, 
+		Priority = true,
+		PurchaseSound = "/SFX/SuperGiftAmbrosiaBottlePickup",
+		-- GameStateRequirements = { RequiredKills = { Theseus = 1 }, },
+	},
+
+	{ 
+		BuyName = "SuperLockKeys", BuyAmount = 1,
+		CostName = "SuperGiftPoints", CostAmount = 1, 
+		Priority = true, 
+		PurchaseSound = "/SFX/TitanBloodPickupSFX",
+		-- GameStateRequirements = { RequiredKills = { Theseus = 1 }, },
+	},
+
+	-- Limited Time Trades
+
+	{ 
+		BuyName = "GiftPoints", BuyAmount = 1,
+		CostName = "Gems", CostAmount = 10, 
+		PurchaseSound = "/SFX/GiftAmbrosiaBottlePickup",
+	},
+
+	{ 
+		BuyName = "LockKeys", BuyAmount = 3,
+		CostName = "MetaPoints", CostAmount = 25, 
+		PurchaseSound = "/SFX/KeyPickup",
+	},
+
+	{ 
+		BuyName = "MetaPoints", BuyAmount = 50,
+		CostName = "GiftPoints", CostAmount = 1, 
+		PurchaseSound = "/SFX/Player Sounds/DarknessCollectionPickup",
+	},
+
+	{ 
+		BuyName = "Gems", BuyAmount = 20,
+		CostName = "LockKeys", CostAmount = 2, 
+		PurchaseSound = "/SFX/GemPickup",
+	},
+
+	{ 
+		BuyName = "SuperLockKeys", BuyAmount = 1,
+		CostName = "LockKeys", CostAmount = 15, 
+		PurchaseSound = "/SFX/TitanBloodPickupSFX",
+		-- GameStateRequirements = { RequiredKills = { Harpy = 1 }, },
+	},
+
+	{ 
+		BuyName = "Gems", BuyAmount = 200,
+		CostName = "SuperLockKeys", CostAmount = 1, 
+		PurchaseSound = "/SFX/GemPickup",
+		-- GameStateRequirements = { RequiredKills = { Harpy = 1 }, },
+	},
+
+	{ 
+		BuyName = "SuperGiftPoints", BuyAmount = 1,
+		CostName = "GiftPoints", CostAmount = 10, 
+		PurchaseSound = "/SFX/SuperGiftAmbrosiaBottlePickup",
+		-- GameStateRequirements = { RequiredKills = { Theseus = 1 }, },
+	},
+
+	{ 
+		BuyName = "SuperGiftPoints", BuyAmount = 1,
+		CostName = "SuperLockKeys", CostAmount = 2, 
+		PurchaseSound = "/SFX/SuperGiftAmbrosiaBottlePickup",
+		-- GameStateRequirements = { RequiredKills = { Hades = 1 }, },
+	},
+
+	{ 
+		BuyName = "SuperGems", BuyAmount = 1,
+		CostName = "SuperLockKeys", CostAmount = 1, 
+		PurchaseSound = "/SFX/SuperGemPickup",
+		-- GameStateRequirements = { RequiredKills = { Hades = 1 }, },
+	},
+
+	{ 
+		BuyName = "SuperGems", BuyAmount = 1,
+		CostName = "Gems", CostAmount = 100, 
+		PurchaseSound = "/SFX/SuperGemPickup",
+		-- GameStateRequirements = { RequiredKills = { HydraHeadImmortal = 1 }, },
+	},
+
+	{ 
+		BuyName = "MetaPoints", BuyAmount = 500,
+		CostName = "SuperGiftPoints", CostAmount = 1, 
+		PurchaseSound = "/SFX/Player Sounds/DarknessCollectionPickup",
+		-- GameStateRequirements = { RequiredKills = { Theseus = 1 }, },
+	},
+
+	{ 
+		BuyName = "Gems", BuyAmount = 50,
+		CostName = "MetaPoints", CostAmount = 300, 
+		PurchaseSound = "/SFX/GemPickup",
+		-- GameStateRequirements = { RequiredMinShrinePointThresholdClear = 1 },
+	},
+}
+
+end)
+
+-- Future:
+
+-- QoL 2: Have the lounge unlocked after the first death
+-- QoL 3: Have the house contractor unlocked after the first death
+-- QoL 4: Have the Fated List of Minor Prophecies unlocked after the first death

--- a/Polycosmos/modfile.txt
+++ b/Polycosmos/modfile.txt
@@ -6,3 +6,11 @@ Import "PolycosmosHeatManager.lua"
 Import "PolycosmosItemManager.lua"
 Import "PolycosmosEvents.lua"
 
+::Polycosmos Quality of Life + Reverse Extreme Measures
+
+Import "PolycosmosQoL.lua"
+To "Scripts/StoreData.lua"
+
+::Polycosmos Reverse Extreme Measures
+::Import "PolycosmosExtremeMeasures.lua"
+::To ???


### PR DESCRIPTION
I've started working on modifying the base game to accommodate the Polycosmos Archipelago Mod. The following changes are provided:

1.) New script `PolycosmosQoL.lua` has been added, with the following properties:
   a.) Unlock all possible sales from the Wretched Broker without need for progression through biomes
   b.) Notes added for future QoL items, like unlocking Broker, House Contractor, and Fated List of Minor Prophecies upon the first failed run instead of when they normally unlock.

2.) New script `PolycosmosExtremeMeasures.lua` has been added, with the following properties:
   a.) This is a placeholder, only comments and no code, but the comments explain the future functionality of the script.
   b.) I kept this separate from the QoL .lua since it will only be active if Reverse Heat is active, and it's also recommended for it to affect logic if this works. These details are in this lua script's comments as well.

3.) Modified `modfile.txt` to import `PolycosmosQoL.lua` and `PolycosmosExtremeMeasures.lua`

Note: Please feel free to remove references/files for `PolycosmosExtremeMeasures.lua`, I'm keeping those here for me specifically. (I probably could've kept those in my fork and not pulled them but I haven't touched GitHub in a while.)