### PR TITLE
Make Deathlink deaths consume Death Defiances before killing the player

### DIFF
--- a/Polycosmos/PolycosmosEvents.lua
+++ b/Polycosmos/PolycosmosEvents.lua
@@ -305,7 +305,12 @@ end)
 function PolycosmosEvents.KillPlayer( message )
     PolycosmosMessages.PrintToPlayer("Deathlink recieved!")
     wait( 2 )
-	KillHero(CurrentRun.Hero,  { }, { })
+    if HasLastStand(CurrentRun.Hero) then
+        CurrentRun.Hero.Health = 0
+        CheckLastStand(CurrentRun.Hero, { })
+    else
+        KillHero(CurrentRun.Hero, { }, { })
+    end
 end
 
 StyxScribe.AddHook( PolycosmosEvents.KillPlayer, styx_scribe_recieve_prefix.."Deathlink recieved", PolycosmosEvents )


### PR DESCRIPTION
Right now, receiving a Deathlink from another player just straight-up kills you, completely bypassing all Death Defiances.
This is notably different from how Deathlink works in other games with a death-protection mechanic. For example, in ALttP a Deathlink "kills" the player, but then they revive if they have a fairy in a bottle.

This change makes it so that Deathlinks will consume a Death Defiance if the player has one.