### PR TITLE
AP Version Info

### DIFF
--- a/Polycosmos/Game/Text/en/PatchNotes.en.sjson
+++ b/Polycosmos/Game/Text/en/PatchNotes.en.sjson
@@ -1,0 +1,10 @@
+{
+  Texts = [
+	"_append"
+	{
+      Id = "DevBuildWatermark"
+      DisplayName = "AP v.0.13.0 | Game v1."
+	  OverwriteLocalization = true
+    }
+  ]
+}

--- a/Polycosmos/modfile.txt
+++ b/Polycosmos/modfile.txt
@@ -34,6 +34,9 @@ SJSON "Game/Animations/ObstacleAnimations.sjson"
 To "Game/GUI/MainMenuScreen.sjson"
 SJSON "Game/GUI/MainMenuScreen.sjson"
 
+To "Game/Text/en/PatchNotes.en.sjson"
+SJSON "Game/Text/en/PatchNotes.en.sjson"
+
 To Win/Packages/LogoInject.pkg_manifest
 Replace "Packages/LogoInject.pkg_manifest"
 


### PR DESCRIPTION
Injecting AP Version into game version text in top right - shows on main menu and I believe in-game pause/menus.

Requires PathNotes.en.sjson to be updated with version number increments