### PR TITLE
Issue 47: Add client command to toggle deathlink

### DIFF
--- a/hades/Client.py
+++ b/hades/Client.py
@@ -30,6 +30,18 @@ class HadesClientCommandProcessor(ClientCommandProcessor):
         #This is a really stupid solution, but it works so idk
         Utils.async_start(self.ctx.check_connection_and_send_items_and_request_starting_info(""))
 
+    def _cmd_deathlink(self) -> bool:
+        """Toggle deathlink tag of client."""
+        if isinstance(self.ctx, HadesContext):
+            # Toggle the deathlink enabled state and set the override flag to prevent automatic enabling from server packages
+            self.ctx.deathlink_enabled = not self.ctx.deathlink_enabled
+            self.ctx.deathlink_client_override = True
+
+            # Send the update to the context which changes the tags for the player
+            Utils.async_start(self.ctx.update_death_link(self.ctx.deathlink_enabled))
+
+        return True
+
 
 class HadesContext(CommonContext):
     # ----------------- Client start up and ending section starts  --------------------------------
@@ -41,6 +53,7 @@ class HadesContext(CommonContext):
     is_connected : bool
     deathlink_pending : bool
     deathlink_enabled : bool
+    deathlink_client_override : bool
     creating_location_to_item_mapping : bool
     is_receiving_items_from_connect_package : bool    
     
@@ -53,6 +66,7 @@ class HadesContext(CommonContext):
         self.is_connected = False
         self.deathlink_pending = False
         self.deathlink_enabled = False
+        self.deathlink_client_override = False
         self.creating_location_to_item_mapping = False
         self.is_receiving_items_from_connect_package = False
 
@@ -117,7 +131,7 @@ class HadesContext(CommonContext):
             
             self.location_name_to_id = self.get_location_name_to_id()
 
-            if "death_link" in self.hades_slot_data and self.hades_slot_data["death_link"]:
+            if "death_link" in self.hades_slot_data and self.hades_slot_data["death_link"] and not self.deathlink_client_override:
                 Utils.async_start(self.update_death_link(True))
                 self.deathlink_enabled = True
             self.is_connected = True


### PR DESCRIPTION
## Description
This PR modifies the Hades client to allow the user to toggle their `DeathLink` tags, regardless of their configured setting. This addresses half of issue #47. The toggle seemed easier to implement than adding configuration for deathlink amnesty. If I can figure that out, I'll open a separate PR.

## Testing
This was tested with a hand-modified `hades.apworld`, interacting with a multiworld hosted on https://archipelago.gg/. Two players both used the modified `hades.apworld` to play with deathlink enabled in the YAML. We went through various combinations of tags on/off while dying in Hades. It seems to be working as I expect (tags set means deathlink on, tags unset means deathlink off).

### Screenshots
#### Command toggling the tags
<img width="531" height="121" alt="image" src="https://github.com/user-attachments/assets/f6fcce0c-d6db-4808-9a01-6f265ab886bc" />

## Notes
I'm not quite sure why some Archipelago commands expect you to use the `!` prefix while others (like this one) require `/`. I don't know quite enough about the text client to understand how to fix that. Along those lines, `/help` and `!help` return different results. That seems to have been the case for the Hades client before this addition (given the `/resync` command), but it felt like it was worth acknowledging.

Also, thanks for making Hades AP a reality! I'm having a blast with it.