### PR TITLE
Issue 47: Add Death Link Amnesty

### DIFF
--- a/hades/Client.py
+++ b/hades/Client.py
@@ -30,6 +30,18 @@ class HadesClientCommandProcessor(ClientCommandProcessor):
         #This is a really stupid solution, but it works so idk
         Utils.async_start(self.ctx.check_connection_and_send_items_and_request_starting_info(""))
 
+    def _cmd_deathlink(self) -> bool:
+        """Toggle deathlink tag of client."""
+        if isinstance(self.ctx, HadesContext):
+            # Toggle the deathlink enabled state and set the override flag to prevent automatic enabling from server packages
+            self.ctx.deathlink_enabled = not self.ctx.deathlink_enabled
+            self.ctx.deathlink_client_override = True
+
+            # Send the update to the context which changes the tags for the player
+            Utils.async_start(self.ctx.update_death_link(self.ctx.deathlink_enabled))
+
+        return True
+
 
 class HadesContext(CommonContext):
     # ----------------- Client start up and ending section starts  --------------------------------
@@ -41,6 +53,7 @@ class HadesContext(CommonContext):
     is_connected : bool
     deathlink_pending : bool
     deathlink_enabled : bool
+    deathlink_client_override : bool
     creating_location_to_item_mapping : bool
     is_receiving_items_from_connect_package : bool    
     
@@ -53,6 +66,7 @@ class HadesContext(CommonContext):
         self.is_connected = False
         self.deathlink_pending = False
         self.deathlink_enabled = False
+        self.deathlink_client_override = False
         self.creating_location_to_item_mapping = False
         self.is_receiving_items_from_connect_package = False
 
@@ -117,7 +131,7 @@ class HadesContext(CommonContext):
             
             self.location_name_to_id = self.get_location_name_to_id()
 
-            if "death_link" in self.hades_slot_data and self.hades_slot_data["death_link"]:
+            if "death_link" in self.hades_slot_data and self.hades_slot_data["death_link"] and not self.deathlink_client_override:
                 Utils.async_start(self.update_death_link(True))
                 self.deathlink_enabled = True
             self.is_connected = True

--- a/hades/Client.py
+++ b/hades/Client.py
@@ -53,6 +53,7 @@ class HadesContext(CommonContext):
     is_connected : bool
     deathlink_pending : bool
     deathlink_enabled : bool
+    deathlink_amnesty_counter : int
     deathlink_client_override : bool
     creating_location_to_item_mapping : bool
     is_receiving_items_from_connect_package : bool    
@@ -66,6 +67,7 @@ class HadesContext(CommonContext):
         self.is_connected = False
         self.deathlink_pending = False
         self.deathlink_enabled = False
+        self.deathlink_amnesty_counter = 0
         self.deathlink_client_override = False
         self.creating_location_to_item_mapping = False
         self.is_receiving_items_from_connect_package = False
@@ -317,13 +319,23 @@ class HadesContext(CommonContext):
         # Avoid sending death if we died from a deathlink
         if self.deathlink_pending or not self.deathlink_enabled:
             return
+        # Increment the amnesty counter and return if we are still in the amnesty period
+        self.deathlink_amnesty_counter += 1
+        if self.deathlink_amnesty_counter < int(self.hades_slot_data["death_link_amnesty"]):
+            logger.info("DeathLink amnesty saved your friends: {}/{} deaths".format(self.deathlink_amnesty_counter, int(self.hades_slot_data["death_link_amnesty"])))
+            return
+
         self.deathlink_pending = True
         Utils.async_start(super().send_death(death_text))
-        Utils.async_start(self.wait_and_lower_deathlink_flag())
+        Utils.async_start(self.wait_and_lower_deathlink_flag(True))
 
-    async def wait_and_lower_deathlink_flag(self) -> None:
+    async def wait_and_lower_deathlink_flag(self, sent_from_self: bool = False) -> None:
         await asyncio.sleep(3)
         self.deathlink_pending = False
+
+        if sent_from_self:
+            # Reset the amnesty counter after we sent out a deathlink
+            self.deathlink_amnesty_counter = 0
 
     # -------------deathlink section ended
 

--- a/hades/Options.py
+++ b/hades/Options.py
@@ -572,6 +572,16 @@ class AutomaticRoomsFinishOnHadesDefeat(Toggle):
     display_name = "Automatic Room Finish On Hades Defeat"
     default = 0
 
+class DeathLinkAmnesty(Range):
+    """
+    Choose the amount of deaths it takes to send a deathlink. 
+    A value of 1 functions as normal deathlink.
+    """
+    display_name = "Death Link Amnesty"
+    range_start = 1
+    range_end = 10
+    default = 1
+
 
 # ------------------------------ Building dictionary ------------------------
 
@@ -631,6 +641,7 @@ class HadesOptions(PerGameCommonOptions):
     disable_late_styx : DisableLateStyx
     automatic_rooms_finish_on_hades_defeat: AutomaticRoomsFinishOnHadesDefeat
     death_link: DeathLink
+    death_link_amnesty: DeathLinkAmnesty
 
 # ------------------------------ Options groups
 
@@ -646,6 +657,7 @@ hades_option_groups = [
         StoreSanity,
         FateSanity,
         DeathLink,
+        DeathLinkAmnesty,
     ]),
     OptionGroup("Goal Options", [
         HadesDefeatsNeeded,

--- a/hades/__init__.py
+++ b/hades/__init__.py
@@ -290,7 +290,8 @@ class HadesWorld(World):
                                          "nectar_pack_value", "ambrosia_pack_value", "filler_helper_percentage",
                                          "max_health_helper_percentage", "initial_money_helper_percentage",
                                          "filler_trap_percentage", "reverse_order_em", "ignore_greece_deaths",
-                                         "store_give_hints", "automatic_rooms_finish_on_hades_defeat", "disable_late_styx", "death_link")
+                                         "store_give_hints", "automatic_rooms_finish_on_hades_defeat", "disable_late_styx", 
+                                         "death_link", "death_link_amnesty")
         slot_data['seed'] = "".join(self.random.choice(string.ascii_letters) for i in range(16))
         slot_data["version_check"] = self.polycosmos_version
         return slot_data


### PR DESCRIPTION
## Description
This PR modifies the Hades options and client to allow for "Death Link Amnesty", enabling users to specify a number of deaths that are required before a DeathLink is sent to the server. If set to 1 (the default value), it behaves as normal DeathLink. When set higher, an informational message is displayed in the client when a player dies, functionally showing how many more times they can die before triggering a DeathLink.

## Testing
This was tested with a hand-modified `hades.apworld`, interacting with a multiworld hosted on https://archipelago.gg/. Three players used the modified `hades.apworld` to play with different `death_link_amnesty` values: 1, 2, and 3. We went through various combinations of dying in Hades to validate the behavior. It seems to be working as I expect. The deaths of the player increment a counter, which when met, triggers a DeathLink to other players. Other players' DeathLinks do not increment the counter, nor reset the counter.

### Screenshots
#### Client showing messages when Death Link Amnesty is set to 2
<img width="460" height="62" alt="image" src="https://github.com/user-attachments/assets/06069106-71a6-4fce-ae88-1cb5ead9b2c2" />

## Notes
This was written after PR #62 and includes that commit as well. Feel free to either close that PR or merge it first. If you'd like, I can cherry pick out this unique commit (aef33f4eed4b5b2f1ee8c9931dc14760026cc7cb). I just didn't want to make you deal with merge conflicts given how close some of the client changes were.

This PR addresses issue #47.
