### PR TITLE
Fix CLI launch args forwarding for client components

### DIFF
--- a/hades/Client.py
+++ b/hades/Client.py
@@ -396,7 +396,7 @@ def launch_hades():
     subsume.Launch(True, None)
 
 
-def launch():
+def launch(*launch_args):
     async def main(args):
         ctx = HadesContext(args.connect, args.password)
         ctx.server_task = Utils.async_start(server_loop(ctx), name="server loop")
@@ -453,7 +453,7 @@ def launch():
     thr = threading.Thread(target=launch_hades, args=(), kwargs={})
     thr.start()
     parser = get_base_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(launch_args)
     colorama.init()
     asyncio.run(main(args))
     colorama.deinit()

--- a/hades/__init__.py
+++ b/hades/__init__.py
@@ -16,9 +16,9 @@ from worlds.AutoWorld import WebWorld, World
 from worlds.LauncherComponents import icon_paths, Component, components, Type, launch_subprocess
 from Utils import local_path
 
-def launch_client():
+def launch_client(*args):
     from .Client import launch
-    launch_subprocess(launch, "HadesClient")
+    launch_subprocess(launch, "HadesClient", args=args)
 
 
 icon_paths['hades_icon'] = f"ap:{__name__}/icons/hades_icon.png"


### PR DESCRIPTION
## Summary
Fixes the client not connecting when launched from the command line or from an Archipelago web link.

Before this fix, a launch like:
```
ArchipelagoLauncher.exe "Game Client" archipelago://PlayerName:Password@archipelago.gg:38281
```
would open the client, but it ignored the server info and did not auto-connect. You have to manually type the slot and click connect.

After this fix, that same command connects to the provided slot automatically.

## Changes
- Pass launch arguments from the launcher into the client
- Have the client read those arguments when it starts

## Testing
- Applied the standard CLI args-forwarding fix
- Installed custom world and attempted above connect command - confirmed slot connects automatically.